### PR TITLE
Update Makefile.z80 for drivewire

### DIFF
--- a/Applications/dw/Makefile.z80
+++ b/Applications/dw/Makefile.z80
@@ -5,7 +5,7 @@ FCCOPTS = -O2
 
 SRCSNS =
 
-SRCS  = dw.c dwgetty.c dwterm.c
+SRCS  = dw.c dwgetty.c dwterm.c dwdate.c
 
 SRCSBAD = 
 


### PR DESCRIPTION
make diskimage for z80 target platforms complains about missing dwdate application